### PR TITLE
Use specific version for jdkato/vale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # `jdkato/vale` installs Vale to `/bin/vale`.
-FROM jdkato/vale
+FROM jdkato/vale:v2.1.1
 
 RUN apk add --no-cache --update nodejs nodejs-npm
 


### PR DESCRIPTION
The latest version of `jdkato/vale` seems to have broke this GitHub action (at least temporarily). Locking the version of the container used can help avoid this problem in the future, by locking down the version of the container being pulled to a known stable version.