### PR TITLE
add onlyAnnotateChangedLines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # `jdkato/vale` installs Vale to `/bin/vale`.
 FROM jdkato/vale
 
-RUN apk add --no-cache --update nodejs nodejs-npm
+RUN apk add --no-cache --update nodejs nodejs-npm git
 
 COPY lib /lib
 COPY package.json /package.json

--- a/README.md
+++ b/README.md
@@ -107,33 +107,19 @@ You can supply this value one of three ways:
 
 - `files: all` (default): The repo's root directory; equivalent to calling `vale .`.
 
+- `files: __onlyModified`: Lint only files that have been modified within a PR.
+
 - `files: path/to/lint`: A single file or directory; equivalent to calling `vale path/to/lint`.
 
 - `files: '["input1", "input2"]'`: A list of file or directory arguments; equivalent to calling `vale input1 input2`.
 
-#### Linting only modified files
+### `onlyAnnotateModifiedLines` (default: `false`)
 
-A common request is to only run Vale on *modified* files. We can make use of the `files` option and the [`file-changes-action`](https://github.com/marketplace/actions/file-changes-action) to do this:
+In case you want the action to only annotate lines that have been modified within a PR. This is helpful in case you're introducing vale to a repository that (still) has a lot of lints and don't want to overwhelm everyone.
 
 ```yaml
-jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v1
-
-    - name: File Changes
-      id: file_changes
-      uses: trilom/file-changes-action@v1.2.3
-
-    - name: Vale
-      uses: errata-ai/vale-action@v1.3.0
-      with:
-        files: '${{ steps.file_changes.outputs.files_modified }}'
-
-      env:
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+with:
+  onlyAnnotateModifiedLines: true
 ```
 
 ## Limitations

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,11 @@ inputs:
     required: false
     default: all
 
+  onlyAnnotateModifiedLines:
+    description: Only post annotations on lines that have changed within a PR.
+    required: false
+    default: 'false'
+
   debug:
     description: 'Log debugging information to stdout'
     required: false
@@ -31,4 +36,5 @@ runs:
     - ${{ inputs.styles }}
     - ${{ inputs.config }}
     - ${{ inputs.files }}
+    - ${{ inputs.onlyAnnotateModifiedLines }}
     - ${{ inputs.debug }}

--- a/lib/check.js
+++ b/lib/check.js
@@ -31,8 +31,10 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.CheckRunner = void 0;
 const core = __importStar(require("@actions/core"));
 const github = __importStar(require("@actions/github"));
+const git_1 = require("./git");
 const pkg = require('../package.json');
 const USER_AGENT = `${pkg.name}/${pkg.version} (${pkg.bugs.url})`;
+const onlyAnnotateModifiedLines = core.getInput('onlyAnnotateModifiedLines') != 'false';
 /**
  * CheckRunner handles all communication with GitHub's Check API.
  *
@@ -44,7 +46,7 @@ class CheckRunner {
         this.stats = {
             suggestions: 0,
             warnings: 0,
-            errors: 0,
+            errors: 0
         };
     }
     /**
@@ -54,6 +56,10 @@ class CheckRunner {
         const alerts = JSON.parse(output);
         for (const filename of Object.getOwnPropertyNames(alerts)) {
             for (const alert of alerts[filename]) {
+                if (onlyAnnotateModifiedLines &&
+                    !git_1.wasLineAddedInPR(filename, alert.Line)) {
+                    continue;
+                }
                 switch (alert.Severity) {
                     case 'suggestion':
                         this.stats.suggestions += 1;
@@ -83,7 +89,7 @@ class CheckRunner {
         return __awaiter(this, void 0, void 0, function* () {
             core.info(`Vale: ${this.getSummary()}`);
             const client = github.getOctokit(options.token, {
-                userAgent: USER_AGENT,
+                userAgent: USER_AGENT
             });
             let checkRunId;
             try {
@@ -131,7 +137,7 @@ class CheckRunner {
                 repo: options.repo,
                 name: options.name,
                 head_sha: options.head_sha,
-                status: 'in_progress',
+                status: 'in_progress'
             });
             if (response.status != 201) {
                 core.warning(`[createCheck] Unexpected status code ${response.status}`);
@@ -158,7 +164,7 @@ class CheckRunner {
                         title: options.name,
                         summary: this.getSummary(),
                         text: this.getText(options.context),
-                        annotations: annotations,
+                        annotations: annotations
                     }
                 };
                 if (this.annotations.length > 0) {
@@ -195,7 +201,7 @@ class CheckRunner {
                 output: {
                     title: options.name,
                     summary: this.getSummary(),
-                    text: this.getText(options.context),
+                    text: this.getText(options.context)
                 }
             };
             const response = yield client.checks.update(req);
@@ -221,7 +227,7 @@ class CheckRunner {
                 output: {
                     title: options.name,
                     summary: 'Unhandled error',
-                    text: 'Check was cancelled due to unhandled error. Check the Action logs for details.',
+                    text: 'Check was cancelled due to unhandled error. Check the Action logs for details.'
                 }
             };
             const response = yield client.checks.update(req);
@@ -291,7 +297,9 @@ class CheckRunner {
      * No alerts found.
      */
     isSuccessCheck() {
-        return this.stats.suggestions == 0 && this.stats.warnings == 0 && this.stats.errors == 0;
+        return (this.stats.suggestions == 0 &&
+            this.stats.warnings == 0 &&
+            this.stats.errors == 0);
     }
     /**
      * Convert Vale-formatted JSON object into an array of annotations:
@@ -338,7 +346,7 @@ class CheckRunner {
             end_column: alert.Span[1],
             annotation_level: annotation_level,
             title: `[${alert.Severity}] ${alert.Check}`,
-            message: alert.Message,
+            message: alert.Message
         };
         return annotation;
     }

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,0 +1,92 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.modifiedFilesInPR = exports.wasLineAddedInPR = void 0;
+const github = __importStar(require("@actions/github"));
+const core = __importStar(require("@actions/core"));
+const execa = require('execa');
+const cache = {};
+function wasLineAddedInPR(filename, line) {
+    var _a, _b, _c;
+    const fromSHA = (_c = (_b = (_a = github.context.payload) === null || _a === void 0 ? void 0 : _a.pull_request) === null || _b === void 0 ? void 0 : _b.base) === null || _c === void 0 ? void 0 : _c.sha;
+    // default to return true when not in the context of a PR.
+    if (!fromSHA)
+        return true;
+    const lines = cache[filename + fromSHA] || addedLines(filename, fromSHA);
+    cache[filename + fromSHA] = lines;
+    return lines.includes(line);
+}
+exports.wasLineAddedInPR = wasLineAddedInPR;
+function modifiedFilesInPR() {
+    var _a, _b, _c;
+    ensureGitHistory();
+    const fromSHA = (_c = (_b = (_a = github.context.payload) === null || _a === void 0 ? void 0 : _a.pull_request) === null || _b === void 0 ? void 0 : _b.base) === null || _c === void 0 ? void 0 : _c.sha;
+    return execa
+        .commandSync(`git diff --name-only ${fromSHA}`)
+        .stdout.toString()
+        .split('\n');
+}
+exports.modifiedFilesInPR = modifiedFilesInPR;
+function addedLines(filename, fromSHA) {
+    try {
+        ensureGitHistory();
+        return (execa
+            // unified=0 => no context around changed lines.
+            .commandSync(`git diff --unified=0 ${fromSHA} ${filename}`)
+            .stdout.toString()
+            .split(/(?:\r\n|\r|\n)/g)
+            // compute the lines that have been added. e.g: `[1, 42]`.
+            .reduce((acc, line) => {
+            // lines starting with @@ mark a hunk. the format is like this:
+            // @@ -(start of removals),(number of removed lines) +(start of insertions),(number of insertions)
+            // here are some examples:
+            // @@ -33,0 +42,24 @@ => removes nothing and inserts 24 lines starting at line 42
+            // @@ -8 +6 @@        => removes line 8 and adds line 6. if there's no comma it's a single-line change.
+            if (!line.startsWith('@@'))
+                return acc;
+            // get the `+` portion, as only additions are relevant in order to filter annotations for portions that are changed.
+            // afterwards split by `,` (no `,` means a single line addition).
+            const [start, numberOfAddedLines = 1] = line.split(' ')[2].split(',');
+            const startInt = parseInt(start, 10);
+            for (let i = 0; i < numberOfAddedLines; i++) {
+                acc.push(startInt + i);
+            }
+            return acc;
+        }, []));
+    }
+    catch (e) {
+        core.error(`Failed to diff ${filename}. ${e.stderr}`);
+        return [];
+    }
+}
+let isHhistoryLoaded = false;
+// make sure we have some history. when using e.g. actions/checkout with its
+// default of `fetch-depth: 1`, we just fetch the commit we're currently looking
+// at. but we want to diff against the base-commit of the PR we're looking at.
+// maybe this could be optimized to fetch exactly that commit.
+function ensureGitHistory() {
+    if (isHhistoryLoaded)
+        return;
+    execa.commandSync('git fetch --unshallow');
+    execa.commandSync('git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"');
+    execa.commandSync('git fetch origin');
+    isHhistoryLoaded = true;
+}

--- a/lib/input.js
+++ b/lib/input.js
@@ -34,13 +34,14 @@ const exec = __importStar(require("@actions/exec"));
 const fs = __importStar(require("fs"));
 const path = __importStar(require("path"));
 const request = __importStar(require("request-promise-native"));
+const git_1 = require("./git");
 /**
  * Log debugging information to `stdout`.
  *
  * @msg is the message to log.
  */
 function logIfDebug(msg) {
-    const debug = (core.getInput('debug') == 'true');
+    const debug = core.getInput('debug') == 'true';
     if (debug) {
         core.info(msg);
     }
@@ -55,7 +56,7 @@ function get(tmp, tok, dir) {
         yield exec.exec('vale', ['-v'], {
             silent: true,
             listeners: {
-                stdout: (buffer) => version = buffer.toString().trim(),
+                stdout: (buffer) => (version = buffer.toString().trim())
             }
         });
         version = version.split(' ').slice(-1)[0];
@@ -68,11 +69,12 @@ function get(tmp, tok, dir) {
         const config = core.getInput('config');
         if (config !== '') {
             logIfDebug(`Downloading external config '${config}' ...`);
-            yield request.get(config)
-                .catch((error) => {
+            yield request
+                .get(config)
+                .catch(error => {
                 core.warning(`Failed to fetch remote config: ${error}.`);
             })
-                .then((body) => {
+                .then(body => {
                 try {
                     fs.writeFileSync(tmp.name, body);
                     logIfDebug(`Successfully fetched remote config.`);
@@ -88,7 +90,10 @@ function get(tmp, tok, dir) {
         const styles = core.getInput('styles').split('\n');
         for (const style of styles) {
             if (style !== '') {
-                const name = style.split('/').slice(-1)[0].split('.zip')[0];
+                const name = style
+                    .split('/')
+                    .slice(-1)[0]
+                    .split('.zip')[0];
                 logIfDebug(`Installing style '${name}' ...`);
                 let cmd = ['install', name, style];
                 if (args.length > 2) {
@@ -99,7 +104,11 @@ function get(tmp, tok, dir) {
         }
         // Figure out what we're supposed to lint:
         const files = core.getInput('files');
-        if (files == 'all') {
+        if (core.getInput('onlyAnnotateModifiedLines') != 'false' ||
+            files == '__onlyModified') {
+            args = args.concat(git_1.modifiedFilesInPR());
+        }
+        else if (files == 'all') {
             args.push('.');
         }
         else if (fs.existsSync(path.resolve(dir, files))) {
@@ -119,7 +128,10 @@ function get(tmp, tok, dir) {
         }
         logIfDebug(`Vale set-up comeplete; using '${args}'.`);
         return {
-            token: tok, workspace: dir, args: args, version: version
+            token: tok,
+            workspace: dir,
+            args: args,
+            version: version
         };
     });
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,0 +1,80 @@
+import * as github from '@actions/github';
+import * as core from '@actions/core';
+
+const execa = require('execa');
+
+type GitRef = string;
+const cache: Record<string, undefined | number[]> = {};
+
+export function wasLineAddedInPR(filename: string, line: number) {
+  const fromSHA: GitRef | undefined =
+    github.context.payload?.pull_request?.base?.sha;
+  // default to return true when not in the context of a PR.
+  if (!fromSHA) return true;
+
+  const lines: number[] =
+    cache[filename + fromSHA] || addedLines(filename, fromSHA);
+  cache[filename + fromSHA] = lines;
+  return lines.includes(line);
+}
+
+export function modifiedFilesInPR() {
+  ensureGitHistory();
+  const fromSHA: GitRef | undefined =
+    github.context.payload?.pull_request?.base?.sha;
+
+  return execa
+    .commandSync(`git diff --name-only ${fromSHA}`)
+    .stdout.toString()
+    .split('\n');
+}
+
+function addedLines(filename: string, fromSHA: GitRef): number[] {
+  try {
+    ensureGitHistory();
+    return (
+      execa
+        // unified=0 => no context around changed lines.
+        .commandSync(`git diff --unified=0 ${fromSHA} ${filename}`)
+        .stdout.toString()
+        .split(/(?:\r\n|\r|\n)/g)
+        // compute the lines that have been added. e.g: `[1, 42]`.
+        .reduce((acc: number[], line: string) => {
+          // lines starting with @@ mark a hunk. the format is like this:
+          // @@ -(start of removals),(number of removed lines) +(start of insertions),(number of insertions)
+          // here are some examples:
+          // @@ -33,0 +42,24 @@ => removes nothing and inserts 24 lines starting at line 42
+          // @@ -8 +6 @@        => removes line 8 and adds line 6. if there's no comma it's a single-line change.
+          if (!line.startsWith('@@')) return acc;
+
+          // get the `+` portion, as only additions are relevant in order to filter annotations for portions that are changed.
+          // afterwards split by `,` (no `,` means a single line addition).
+          const [start, numberOfAddedLines = 1] = line.split(' ')[2].split(',');
+
+          const startInt = parseInt(start, 10);
+          for (let i = 0; i < numberOfAddedLines; i++) {
+            acc.push(startInt + i);
+          }
+          return acc;
+        }, [])
+    );
+  } catch (e) {
+    core.error(`Failed to diff ${filename}. ${e.stderr}`);
+    return [];
+  }
+}
+
+let isHhistoryLoaded = false;
+// make sure we have some history. when using e.g. actions/checkout with its
+// default of `fetch-depth: 1`, we just fetch the commit we're currently looking
+// at. but we want to diff against the base-commit of the PR we're looking at.
+// maybe this could be optimized to fetch exactly that commit.
+function ensureGitHistory() {
+  if (isHhistoryLoaded) return;
+  execa.commandSync('git fetch --unshallow');
+  execa.commandSync(
+    'git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"'
+  );
+  execa.commandSync('git fetch origin');
+  isHhistoryLoaded = true;
+}

--- a/src/input.ts
+++ b/src/input.ts
@@ -4,6 +4,7 @@ import * as exec from '@actions/exec';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as request from 'request-promise-native';
+import {modifiedFilesInPR} from './git';
 
 /**
  * Our expected input.
@@ -93,7 +94,12 @@ export async function get(tmp: any, tok: string, dir: string): Promise<Input> {
 
   // Figure out what we're supposed to lint:
   const files = core.getInput('files');
-  if (files == 'all') {
+  if (
+    core.getInput('onlyAnnotateModifiedLines') != 'false' ||
+    files == '__onlyModified'
+  ) {
+    args = args.concat(modifiedFilesInPR());
+  } else if (files == 'all') {
     args.push('.');
   } else if (fs.existsSync(path.resolve(dir, files))) {
     args.push(files);


### PR DESCRIPTION
when `onlyAnnotateModifiedLines` is set to `"true"`, we'll filter vales alerts for whether they reference a line that has been touched in this PR. please think a minute about whether `onlyAnnotateAddedLines` or `onlyAnnotateTouchedLines` might prevent confusion. my opinion about whether `touched` or `modified` is better changes hourly - i think `added` - while being technically correct - would cause misunderstandings.

additionally we introduce a "native" way to only lint modified **files** by specifying `files: __onlyModified`. i'm not sure about whether it's a good idea to "abuse" `files` though and would love to hear more opinions on that.

maybe we should also add a note that this option is only intended to be used with `on: pull_request`.

@jdkato feel free to modify/alter any of those changes.