### PR TITLE
fix: Do not run vale if there is no file being modified

### DIFF
--- a/lib/input.js
+++ b/lib/input.js
@@ -126,6 +126,12 @@ function get(tmp, tok, dir) {
                     modified[file.name] = file;
                 }
             });
+            // add empty file is there is no file to lint
+            // else execa will wait forever as --no-exit flag is given
+            // and there is no argument given
+            if (names.size === 0) {
+                names.add('{}');
+            }
             args = args.concat(Array.from(names));
         }
         else if (files == 'all') {

--- a/src/input.ts
+++ b/src/input.ts
@@ -123,7 +123,12 @@ export async function get(tmp: any, tok: string, dir: string): Promise<Input> {
         modified[file.name] = file;
       }
     });
-
+    // add empty file is there is no file to lint
+    // else execa will wait forever as --no-exit flag is given
+    // and there is no argument given
+    if (names.size === 0) {
+      names.add('{}');
+    }
     args = args.concat(Array.from(names));
   } else if (files == 'all') {
     args.push('.');


### PR DESCRIPTION
fixes https://github.com/errata-ai/vale-action/issues/39

When there is no file to check, the list of arguments don't have any files, so vale is failing but as we provide --no-exit flag, it doesn't exit and then, process is waiting for ever.

Here, provides a dumb path to scan so we run vale on empty set of file instead of not having the set of files