### PR TITLE
feat: allow to override default sha when using action in a post-workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,34 @@ Due to the current [token permissions](https://help.github.com/en/articles/virtu
 this Action **CAN NOT** post annotations to PRs from forked repositories.
 
 This will likely be fixed by [toolkit/issues/186](https://github.com/actions/toolkit/issues/186).
+
+A workaround is to run this action as a follow-up workflow.
+For example, pull_request workflow generates source artifact and post-workflow scan artifact with vale and then annotate the commit. Use `OVERRIDE_GITHUB_SHA` environment variable to override the commit SHA to annotate if matching a Pull Request.
+
+
+```yaml
+
+on:
+  workflow_run:
+    workflows: ["PR check"]
+    types:
+      - completed
+
+jobs:
+  vale:
+    runs-on: ubuntu-20.04
+    steps:
+      ...
+      - name: Grab pull request sha1
+        run: |
+          ....
+          echo "PR_SHA=$pr_sha" >> $GITHUB_ENV
+      - name: Vale Linter
+        uses: errata-ai/vale-action@v1.4.3
+        with:
+          ...
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          OVERRIDE_GITHUB_SHA: ${{env.PR_SHA}}
+
+```          

--- a/lib/main.js
+++ b/lib/main.js
@@ -54,6 +54,11 @@ function run(actionInput) {
             if (github.context.payload.pull_request) {
                 sha = github.context.payload.pull_request.head.sha;
             }
+            // Allow to customize the SHA to use for the check
+            // useful when using the action with a workflow_run/completed event
+            if (process.env.OVERRIDE_GITHUB_SHA) {
+                sha = process.env.OVERRIDE_GITHUB_SHA;
+            }
             runner.makeAnnotations(alertResp.stdout);
             yield runner.executeCheck({
                 token: actionInput.token,

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,12 @@ export async function run(actionInput: input.Input): Promise<void> {
       sha = github.context.payload.pull_request.head.sha;
     }
 
+    // Allow to customize the SHA to use for the check
+    // useful when using the action with a workflow_run/completed event
+    if (process.env.OVERRIDE_GITHUB_SHA) {
+      sha = process.env.OVERRIDE_GITHUB_SHA;
+    }
+
     runner.makeAnnotations(alertResp.stdout);
     await runner.executeCheck({
       token: actionInput.token,


### PR DESCRIPTION
Action runs smoothly when using pull_request/push events

but it does not work well when using completed workflow

In order to use this action using forked repositories, there are two ways
- use pull_request_target event on the sha of the pull_request (but it's mostly discouraged as it can lead to security issues)
- use a pull_request workflow that collect files (like asciidoc files) and add them to a workflow artifact. Then another workflow is triggered to scan this temporary artifact with the current vale action. It works fine but the result is not applied to the correct git SHA. So add an environment variable to handle that.

I'm fine if you prefer to introduce a new input parameter for that.

