### PR TITLE
Add support for `workflow_run` event

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -91,7 +91,18 @@ async function getCommits(): Promise<string[]> {
       });
       break;
     default:
-      core.warning(`Unrecognized event: ${CTX.eventName}`);
+      if (process.env.OVERRIDE_PR_NUMBER) {
+        const resp = await API.request('GET /repos/{owner}/{repo}/pulls/{pull_number}/commits', {
+          owner: CTX.repo.owner,
+          repo: CTX.repo.repo,
+          pull_number: process.env.OVERRIDE_PR_NUMBER
+        })
+
+        resp.data.forEach((commit: { sha: string }) => {
+          commits.push(commit.sha);
+        });
+      }
+      else { core.warning(`Unrecognized event: ${CTX.eventName}`); }
   }
 
   return commits;


### PR DESCRIPTION
Fix #58 

The list of commits is only generated if the event triggering the workflow is `push` or `pull_request`. So for PR from a forked repo, the `actionInput.files` is an empty list, and so when using `onlyAnnotateModifiedLines` the workflow does not add any comment

To support other events, I propose to add an env variable `OVERRIDE_PR_NUMBER` which with the owner and the repo variable allows to directly call the github API to fetch commits
